### PR TITLE
✨ Add basicmessages

### DIFF
--- a/nats_events/nats_events/v1_0/nats_queue/events/__init__.py
+++ b/nats_events/nats_events/v1_0/nats_queue/events/__init__.py
@@ -49,6 +49,7 @@ async def setup(context: InjectionContext):
 
 RECORD_RE = re.compile(r"acapy::record::([^:]*)(?:::(.*))?")
 WEBHOOK_RE = re.compile(r"acapy::webhook::{.*}")
+MESSAGE_RE = re.compile(r"acapy::basicmessage::{.*}")
 
 
 async def nats_jetstream_setup(profile: Profile, event: Event) -> JetStreamContext:
@@ -178,6 +179,8 @@ def _derive_category(topic: str):
         return match.group(1)
     if WEBHOOK_RE.match(topic):
         return "webhook"
+    if MESSAGE_RE.match(topic):
+        return "basicmessage"
 
 
 def process_event_payload(event_payload: Any):


### PR DESCRIPTION
Populate `category` for `acapy::basicmessage::`

The basic-message event looks like this in NATS:

```json
{
  "payload":
    {
      "wallet_id": "b8f2b8ec-6bb5-4569-89c6-403de1e9155a",
      "state": "received",
      "topic": "acapy::basicmessage::received",
      "category": null,
      "payload":
        {
          "connection_id": "4fc222a1-0588-4076-81ff-4da3222a92ca",
          "message_id": "a3b80551-e67f-4f05-91fe-ae93df9b2af1",
          "content": "Asdf",
          "state": "received",
          "sent_time": "2025-06-10T07:18:30.970515Z",
        },
    },
  "metadata":
    {
      "time_ns": 1749539910994675747,
      "x-wallet-id": "b8f2b8ec-6bb5-4569-89c6-403de1e9155a",
      "group_id": "TenantGroup",
      "origin": "bob_ZKFXS",
    },
}
```