### PR TITLE
🩹 remove schema name from resourceName

### DIFF
--- a/cheqd/cheqd/anoncreds/registry.py
+++ b/cheqd/cheqd/anoncreds/registry.py
@@ -291,7 +291,7 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Register a credential definition on the registry."""
         resource_type = CheqdAnonCredsResourceType.credentialDefinition.value
         # TODO: max chars are 31 for resource, on exceeding this should be hashed
-        resource_name = f"{schema.schema_value.name}-{credential_definition.tag}"
+        resource_name = f"{credential_definition.tag}"
 
         cred_def = ResourceCreateRequestOptions(
             options=Options(


### PR DESCRIPTION
When `resourceName` gets too long backup revRegs creation fails.
Removing `schemaName` 

